### PR TITLE
fix(social) Accept user models w/o usernames

### DIFF
--- a/auth_kit/social/serializers/login.py
+++ b/auth_kit/social/serializers/login.py
@@ -193,7 +193,9 @@ class SocialLoginWithTokenRequestSerializer(serializers.Serializer[dict[str, Any
         Args:
             login: The SocialLogin instance to configure
         """
-        if not login.user.username and getattr(UserModel, "USERNAME_FIELD", None):
+        if not getattr(login.user, "username", None) and getattr(
+            UserModel, "USERNAME_FIELD", None
+        ):
             username_field = UserModel.USERNAME_FIELD
             setattr(
                 login.user, username_field, login.user.email


### PR DESCRIPTION
Changes the set_user_login method to do a getattr instead of a direct reference so that in the event the custom user model does not have the username field, it does not crash