### PR TITLE
fix(social): wipe password on email-authenticated social login

### DIFF
--- a/auth_kit/social/serializers/login.py
+++ b/auth_kit/social/serializers/login.py
@@ -17,6 +17,9 @@ import structlog
 from allauth.account.utils import (  # pyright: ignore[reportMissingTypeStubs]
     filter_users_by_email,
 )
+from allauth.socialaccount.internal.flows.email_authentication import (  # pyright: ignore[reportMissingTypeStubs]
+    wipe_password,
+)
 from allauth.socialaccount.models import (  # pyright: ignore[reportMissingTypeStubs]
     SocialApp,
     SocialToken,
@@ -97,6 +100,11 @@ class SocialLoginWithTokenRequestSerializer(serializers.Serializer[dict[str, Any
             login: The SocialLogin instance to process
         """
         login.lookup()
+
+        # Mirror allauth's _accept_login: wipe password when authenticated by email
+        # to prevent attacker account-takeover via unverified email registration.
+        if login._did_authenticate_by_email:
+            wipe_password(request, login.user, login._did_authenticate_by_email)
 
         # If allauth's lookup didn't find a user (e.g., because
         # SOCIALACCOUNT_EMAIL_AUTHENTICATION=False), do our own lookup

--- a/sandbox/test_auth_kit/social/views/test_login.py
+++ b/sandbox/test_auth_kit/social/views/test_login.py
@@ -549,6 +549,31 @@ class TestCrossProviderLogin(SocialLoginTestCase):
 
     @responses.activate
     @override_auth_kit_settings(SOCIAL_LOGIN_AUTO_CONNECT_BY_EMAIL=True)
+    def test_social_login_wipes_password_when_authenticated_by_email(self) -> None:
+        """
+        Social login that matches an existing account by email must wipe the
+        password to prevent the attacker account-takeover scenario described in
+        allauth's wipe_password docs (forthecraft/drf-auth-kit#47).
+        """
+        user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="attacker_password"
+        )
+        assert user.has_usable_password()
+
+        self.mock_oauth_responses("google")
+
+        url = reverse("rest_social_google_login")
+        response: Response = self.client.post(
+            url, {"code": "test-authorization-code"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        user.refresh_from_db()
+        assert not user.has_usable_password()
+
+    @responses.activate
+    @override_auth_kit_settings(SOCIAL_LOGIN_AUTO_CONNECT_BY_EMAIL=True)
     def test_cross_provider_login_with_allauth_email_auth_disabled(self) -> None:
         """
         Test that auth_kit's SOCIAL_LOGIN_AUTO_CONNECT_BY_EMAIL works independently


### PR DESCRIPTION
## Summary

- Calls `wipe_password` in `handle_social_login` after `login.lookup()` when `_did_authenticate_by_email` is set, mirroring allauth's own `_accept_login` behaviour.
- Prevents the attacker account-takeover scenario where an attacker registers with a victim's unverified email+password, then retains login access after the victim authenticates via social/OAuth.

Fixes #47

## Changes

- **`auth_kit/social/serializers/login.py`**: Import `wipe_password` from `allauth.socialaccount.internal.flows.email_authentication` and call it when `login._did_authenticate_by_email` is truthy.
- **`sandbox/test_auth_kit/social/views/test_login.py`**: Add `test_social_login_wipes_password_when_authenticated_by_email` to verify the password is wiped after an email-matched social login.

## Test plan

- [x] New test `test_social_login_wipes_password_when_authenticated_by_email` passes — creates user with password, logs in via Google OAuth with same email, asserts `has_usable_password()` is `False`
- [x] All 42 existing social tests pass unchanged